### PR TITLE
feat: Design Supabase database schema for core features

### DIFF
--- a/emails.sql
+++ b/emails.sql
@@ -1,0 +1,52 @@
+-- メールテーブル
+CREATE TABLE public.emails (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(), -- メールID
+    message_id TEXT UNIQUE, -- メールシステム固有のメッセージID (重複取込防止用)
+    received_at TIMESTAMPTZ NOT NULL DEFAULT now(), -- 受信日時
+    sender_address TEXT NOT NULL, -- 送信者メールアドレス
+    recipient_address TEXT, -- 受信者メールアドレス
+    subject TEXT, -- 件名
+    body_text TEXT, -- メール本文 (テキスト形式)
+    body_html TEXT, -- メール本文 (HTML形式)
+    attachments_info JSONB, -- 添付ファイル情報 (ファイル名, S3キーなど)
+    processing_status TEXT NOT NULL DEFAULT 'pending' CHECK (processing_status IN ('pending', 'processing', 'processed_project_created', 'processed_engineer_created', 'processed_no_relevant_info', 'error_parsing', 'manual_review_required')), -- 処理ステータス
+    extracted_project_id UUID REFERENCES public.projects(id), -- 抽出された案件ID
+    extracted_engineer_id UUID REFERENCES public.engineers(id), -- 抽出された技術者ID
+    error_message TEXT, -- エラーメッセージ (処理失敗時)
+    notes TEXT, -- 処理に関するメモ
+    created_at TIMESTAMPTZ DEFAULT now(), -- 作成日時
+    updated_at TIMESTAMPTZ DEFAULT now() -- 更新日時
+);
+
+-- コメント追加
+COMMENT ON TABLE public.emails IS 'メールテーブル';
+COMMENT ON COLUMN public.emails.id IS 'メールID';
+COMMENT ON COLUMN public.emails.message_id IS 'メールシステム固有のメッセージID (重複取込防止用)';
+COMMENT ON COLUMN public.emails.received_at IS '受信日時';
+COMMENT ON COLUMN public.emails.sender_address IS '送信者メールアドレス';
+COMMENT ON COLUMN public.emails.recipient_address IS '受信者メールアドレス';
+COMMENT ON COLUMN public.emails.subject IS '件名';
+COMMENT ON COLUMN public.emails.body_text IS 'メール本文 (テキスト形式)';
+COMMENT ON COLUMN public.emails.body_html IS 'メール本文 (HTML形式)';
+COMMENT ON COLUMN public.emails.attachments_info IS '添付ファイル情報 (ファイル名, S3キーなど)';
+COMMENT ON COLUMN public.emails.processing_status IS '処理ステータス';
+COMMENT ON COLUMN public.emails.extracted_project_id IS '抽出された案件ID';
+COMMENT ON COLUMN public.emails.extracted_engineer_id IS '抽出された技術者ID';
+COMMENT ON COLUMN public.emails.error_message IS 'エラーメッセージ (処理失敗時)';
+COMMENT ON COLUMN public.emails.notes IS '処理に関するメモ';
+COMMENT ON COLUMN public.emails.created_at IS '作成日時';
+COMMENT ON COLUMN public.emails.updated_at IS '更新日時';
+
+-- インデックス作成
+CREATE INDEX idx_emails_received_at ON public.emails(received_at);
+CREATE INDEX idx_emails_sender_address ON public.emails(sender_address);
+CREATE INDEX idx_emails_recipient_address ON public.emails(recipient_address);
+CREATE INDEX idx_emails_processing_status ON public.emails(processing_status);
+CREATE INDEX idx_emails_extracted_project_id ON public.emails(extracted_project_id);
+CREATE INDEX idx_emails_extracted_engineer_id ON public.emails(extracted_engineer_id);
+
+-- updated_at トリガー (既に trigger_set_timestamp() 関数が定義されていると仮定)
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON public.emails
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();

--- a/engineers.sql
+++ b/engineers.sql
@@ -1,0 +1,62 @@
+-- 技術者テーブル
+CREATE TABLE public.engineers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(), -- 技術者ID
+    user_id UUID REFERENCES public.profiles(id), -- 関連ユーザーID (システムユーザーの場合)
+    tenant_id UUID REFERENCES public.tenants(id), -- 所属会社ID (自社・他社技術者の区別)
+    name TEXT NOT NULL, -- 氏名 (氏名は必須とする)
+    email TEXT UNIQUE, -- メールアドレス (一意であるべき)
+    phone TEXT, -- 電話番号
+    status TEXT DEFAULT 'available' CHECK (status IN ('available', 'assigned', 'inactive', 'pending_review')), -- ステータス (利用可能、アサイン中、非アクティブ、レビュー待ち)
+    skills JSONB, -- スキル (構造化データ)
+    experience JSONB, -- 職務経歴 (構造化データ)
+    education JSONB, -- 学歴 (構造化データ)
+    preferences JSONB, -- 希望条件 (構造化データ)
+    raw_resume_text TEXT, -- AI解析前の履歴書テキスト
+    source_document_url TEXT, -- 元の履歴書ドキュメントURL (例: S3バケットのパス)
+    source_details TEXT, -- 情報源詳細 (例: "resume_upload", "email_extraction")
+    is_external BOOLEAN DEFAULT false, -- 外部技術者フラグ (自社管理でない場合)
+    created_at TIMESTAMPTZ DEFAULT now(), -- 作成日時
+    updated_at TIMESTAMPTZ DEFAULT now() -- 更新日時
+);
+
+-- コメント追加
+COMMENT ON TABLE public.engineers IS '技術者テーブル';
+COMMENT ON COLUMN public.engineers.id IS '技術者ID';
+COMMENT ON COLUMN public.engineers.user_id IS '関連ユーザーID (システムユーザーの場合)';
+COMMENT ON COLUMN public.engineers.tenant_id IS '所属会社ID (自社・他社技術者の区別)';
+COMMENT ON COLUMN public.engineers.name IS '氏名 (氏名は必須とする)';
+COMMENT ON COLUMN public.engineers.email IS 'メールアドレス (一意であるべき)';
+COMMENT ON COLUMN public.engineers.phone IS '電話番号';
+COMMENT ON COLUMN public.engineers.status IS 'ステータス (利用可能、アサイン中、非アクティブ、レビュー待ち)';
+COMMENT ON COLUMN public.engineers.skills IS 'スキル (構造化データ)';
+COMMENT ON COLUMN public.engineers.experience IS '職務経歴 (構造化データ)';
+COMMENT ON COLUMN public.engineers.education IS '学歴 (構造化データ)';
+COMMENT ON COLUMN public.engineers.preferences IS '希望条件 (構造化データ)';
+COMMENT ON COLUMN public.engineers.raw_resume_text IS 'AI解析前の履歴書テキスト';
+COMMENT ON COLUMN public.engineers.source_document_url IS '元の履歴書ドキュメントURL (例: S3バケットのパス)';
+COMMENT ON COLUMN public.engineers.source_details IS '情報源詳細 (例: "resume_upload", "email_extraction")';
+COMMENT ON COLUMN public.engineers.is_external IS '外部技術者フラグ (自社管理でない場合)';
+COMMENT ON COLUMN public.engineers.created_at IS '作成日時';
+COMMENT ON COLUMN public.engineers.updated_at IS '更新日時';
+
+-- インデックス作成
+CREATE INDEX idx_engineers_user_id ON public.engineers(user_id);
+CREATE INDEX idx_engineers_tenant_id ON public.engineers(tenant_id);
+CREATE INDEX idx_engineers_email ON public.engineers(email);
+CREATE INDEX idx_engineers_status ON public.engineers(status);
+CREATE INDEX idx_engineers_skills ON public.engineers USING GIN (skills);
+
+-- updated_at トリガー関数
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- updated_at トリガー
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON public.engineers
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();

--- a/project_engineer_matches.sql
+++ b/project_engineer_matches.sql
@@ -1,0 +1,42 @@
+-- 案件技術者マッチングテーブル
+CREATE TABLE public.project_engineer_matches (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(), -- マッチングID
+    project_id UUID NOT NULL REFERENCES public.projects(id), -- 案件ID
+    engineer_id UUID NOT NULL REFERENCES public.engineers(id), -- 技術者ID
+    match_score FLOAT CHECK (match_score >= 0.0 AND match_score <= 1.0), -- AIによるマッチングスコア (0.0〜1.0)
+    match_type TEXT NOT NULL CHECK (match_type IN ('project_to_engineer', 'engineer_to_project', 'batch_n_to_n', 'manual_suggestion')), -- マッチングタイプ (案件から技術者へ, 技術者から案件へ, バッチn対n, 手動提案)
+    status TEXT NOT NULL DEFAULT 'suggested' CHECK (status IN ('suggested', 'pending_review', 'shortlisted', 'proposed_to_company', 'proposed_to_engineer', 'accepted_by_company', 'accepted_by_engineer', 'match_confirmed', 'rejected_by_company', 'rejected_by_engineer', 'archived')), -- ステータス
+    ai_match_details JSONB, -- AIマッチング詳細 (理由、使用特徴量など)
+    notes TEXT, -- 手動メモ (このマッチングに関する)
+    created_by_user_id UUID REFERENCES public.profiles(id), -- 作成ユーザーID (手動提案の場合など)
+    created_at TIMESTAMPTZ DEFAULT now(), -- 作成日時
+    updated_at TIMESTAMPTZ DEFAULT now(), -- 更新日時
+    CONSTRAINT uq_project_engineer_match_type UNIQUE (project_id, engineer_id, match_type)
+);
+
+-- コメント追加
+COMMENT ON TABLE public.project_engineer_matches IS '案件技術者マッチングテーブル';
+COMMENT ON COLUMN public.project_engineer_matches.id IS 'マッチングID';
+COMMENT ON COLUMN public.project_engineer_matches.project_id IS '案件ID';
+COMMENT ON COLUMN public.project_engineer_matches.engineer_id IS '技術者ID';
+COMMENT ON COLUMN public.project_engineer_matches.match_score IS 'AIによるマッチングスコア (0.0〜1.0)';
+COMMENT ON COLUMN public.project_engineer_matches.match_type IS 'マッチングタイプ (案件から技術者へ, 技術者から案件へ, バッチn対n, 手動提案)';
+COMMENT ON COLUMN public.project_engineer_matches.status IS 'ステータス';
+COMMENT ON COLUMN public.project_engineer_matches.ai_match_details IS 'AIマッチング詳細 (理由、使用特徴量など)';
+COMMENT ON COLUMN public.project_engineer_matches.notes IS '手動メモ (このマッチングに関する)';
+COMMENT ON COLUMN public.project_engineer_matches.created_by_user_id IS '作成ユーザーID (手動提案の場合など)';
+COMMENT ON COLUMN public.project_engineer_matches.created_at IS '作成日時';
+COMMENT ON COLUMN public.project_engineer_matches.updated_at IS '更新日時';
+
+-- インデックス作成
+CREATE INDEX idx_pem_project_id ON public.project_engineer_matches(project_id);
+CREATE INDEX idx_pem_engineer_id ON public.project_engineer_matches(engineer_id);
+CREATE INDEX idx_pem_match_type ON public.project_engineer_matches(match_type);
+CREATE INDEX idx_pem_status ON public.project_engineer_matches(status);
+CREATE INDEX idx_pem_created_by_user_id ON public.project_engineer_matches(created_by_user_id);
+
+-- updated_at トリガー (既に trigger_set_timestamp() 関数が定義されていると仮定)
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON public.project_engineer_matches
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();

--- a/projects.sql
+++ b/projects.sql
@@ -1,0 +1,65 @@
+-- 案件テーブル
+CREATE TABLE public.projects (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(), -- 案件ID
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id), -- 案件所属会社ID (自社・他社案件の区別)
+    created_by_user_id UUID REFERENCES public.profiles(id), -- 作成ユーザーID
+    title TEXT NOT NULL, -- 案件名
+    description TEXT, -- 案件詳細
+    status TEXT DEFAULT 'open' CHECK (status IN ('open', 'in_progress', 'closed', 'filled', 'on_hold', 'pending_approval')), -- ステータス (募集中、進行中、終了、充足、保留中、承認待ち)
+    required_skills JSONB, -- 必須スキル (構造化データ)
+    preferred_skills JSONB, -- 推奨スキル (構造化データ)
+    budget NUMERIC, -- 予算
+    start_date DATE, -- 開始予定日
+    end_date DATE, -- 終了予定日
+    location TEXT, -- 場所
+    raw_input_text TEXT, -- AI解析前の案件情報テキスト (メール本文、口頭メモなど)
+    source_document_url TEXT, -- 元の案件ドキュメントURL (例: S3バケットのパス)
+    source_details TEXT, -- 情報源詳細 (例: "email_extraction", "pdf_import", "manual_entry")
+    is_external BOOLEAN DEFAULT false, -- 外部案件フラグ (自社案件でない場合)
+    created_at TIMESTAMPTZ DEFAULT now(), -- 作成日時
+    updated_at TIMESTAMPTZ DEFAULT now() -- 更新日時
+);
+
+-- コメント追加
+COMMENT ON TABLE public.projects IS '案件テーブル';
+COMMENT ON COLUMN public.projects.id IS '案件ID';
+COMMENT ON COLUMN public.projects.tenant_id IS '案件所属会社ID (自社・他社案件の区別)';
+COMMENT ON COLUMN public.projects.created_by_user_id IS '作成ユーザーID';
+COMMENT ON COLUMN public.projects.title IS '案件名';
+COMMENT ON COLUMN public.projects.description IS '案件詳細';
+COMMENT ON COLUMN public.projects.status IS 'ステータス (募集中、進行中、終了、充足、保留中、承認待ち)';
+COMMENT ON COLUMN public.projects.required_skills IS '必須スキル (構造化データ)';
+COMMENT ON COLUMN public.projects.preferred_skills IS '推奨スキル (構造化データ)';
+COMMENT ON COLUMN public.projects.budget IS '予算';
+COMMENT ON COLUMN public.projects.start_date IS '開始予定日';
+COMMENT ON COLUMN public.projects.end_date IS '終了予定日';
+COMMENT ON COLUMN public.projects.location IS '場所';
+COMMENT ON COLUMN public.projects.raw_input_text IS 'AI解析前の案件情報テキスト (メール本文、口頭メモなど)';
+COMMENT ON COLUMN public.projects.source_document_url IS '元の案件ドキュメントURL (例: S3バケットのパス)';
+COMMENT ON COLUMN public.projects.source_details IS '情報源詳細 (例: "email_extraction", "pdf_import", "manual_entry")';
+COMMENT ON COLUMN public.projects.is_external IS '外部案件フラグ (自社案件でない場合)';
+COMMENT ON COLUMN public.projects.created_at IS '作成日時';
+COMMENT ON COLUMN public.projects.updated_at IS '更新日時';
+
+-- インデックス作成
+CREATE INDEX idx_projects_tenant_id ON public.projects(tenant_id);
+CREATE INDEX idx_projects_created_by_user_id ON public.projects(created_by_user_id);
+CREATE INDEX idx_projects_status ON public.projects(status);
+CREATE INDEX idx_projects_start_date ON public.projects(start_date);
+CREATE INDEX idx_projects_required_skills ON public.projects USING GIN (required_skills);
+CREATE INDEX idx_projects_preferred_skills ON public.projects USING GIN (preferred_skills);
+
+-- updated_at トリガー関数 (engineers.sqlで既に定義されている場合は再定義不要)
+-- CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+-- RETURNS TRIGGER AS $$
+-- BEGIN
+--   NEW.updated_at = NOW();
+--   RETURN NEW;
+-- END;
+-- $$ LANGUAGE plpgsql;
+
+-- updated_at トリガー
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON public.projects
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();

--- a/proposals.sql
+++ b/proposals.sql
@@ -1,0 +1,51 @@
+-- 提案テーブル
+CREATE TABLE public.proposals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(), -- 提案ID
+    match_id UUID NOT NULL REFERENCES public.project_engineer_matches(id), -- 関連マッチングID
+    proposal_type TEXT NOT NULL CHECK (proposal_type IN ('project_proposal_to_engineer', 'engineer_recommendation_to_company')), -- 提案タイプ (技術者への案件提案, 企業への技術者推薦)
+    recipient_email TEXT NOT NULL, -- 送信先メールアドレス
+    recipient_user_id UUID REFERENCES public.profiles(id), -- 受信者ユーザーID (システム内のユーザーの場合)
+    recipient_engineer_id UUID REFERENCES public.engineers(id), -- 受信者技術者ID (システム内の技術者の場合)
+    subject TEXT NOT NULL, -- 送信メール件名
+    body_template_used TEXT, -- 使用されたメールテンプレートID
+    body_ai_summary TEXT, -- AIによる自動要約内容
+    body_final_content TEXT NOT NULL, -- (編集後の)最終メール本文
+    sent_at TIMESTAMPTZ, -- 送信日時
+    status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'sending', 'sent_successfully', 'failed_to_send', 'opened', 'clicked', 'replied', 'archived')), -- 送信ステータス
+    created_by_user_id UUID NOT NULL REFERENCES public.profiles(id), -- 作成ユーザーID
+    created_at TIMESTAMPTZ DEFAULT now(), -- 作成日時
+    updated_at TIMESTAMPTZ DEFAULT now() -- 更新日時
+);
+
+-- コメント追加
+COMMENT ON TABLE public.proposals IS '提案テーブル';
+COMMENT ON COLUMN public.proposals.id IS '提案ID';
+COMMENT ON COLUMN public.proposals.match_id IS '関連マッチングID';
+COMMENT ON COLUMN public.proposals.proposal_type IS '提案タイプ (技術者への案件提案, 企業への技術者推薦)';
+COMMENT ON COLUMN public.proposals.recipient_email IS '送信先メールアドレス';
+COMMENT ON COLUMN public.proposals.recipient_user_id IS '受信者ユーザーID (システム内のユーザーの場合)';
+COMMENT ON COLUMN public.proposals.recipient_engineer_id IS '受信者技術者ID (システム内の技術者の場合)';
+COMMENT ON COLUMN public.proposals.subject IS '送信メール件名';
+COMMENT ON COLUMN public.proposals.body_template_used IS '使用されたメールテンプレートID';
+COMMENT ON COLUMN public.proposals.body_ai_summary IS 'AIによる自動要約内容';
+COMMENT ON COLUMN public.proposals.body_final_content IS '(編集後の)最終メール本文';
+COMMENT ON COLUMN public.proposals.sent_at IS '送信日時';
+COMMENT ON COLUMN public.proposals.status IS '送信ステータス';
+COMMENT ON COLUMN public.proposals.created_by_user_id IS '作成ユーザーID';
+COMMENT ON COLUMN public.proposals.created_at IS '作成日時';
+COMMENT ON COLUMN public.proposals.updated_at IS '更新日時';
+
+-- インデックス作成
+CREATE INDEX idx_proposals_match_id ON public.proposals(match_id);
+CREATE INDEX idx_proposals_proposal_type ON public.proposals(proposal_type);
+CREATE INDEX idx_proposals_recipient_email ON public.proposals(recipient_email);
+CREATE INDEX idx_proposals_recipient_user_id ON public.proposals(recipient_user_id);
+CREATE INDEX idx_proposals_recipient_engineer_id ON public.proposals(recipient_engineer_id);
+CREATE INDEX idx_proposals_status ON public.proposals(status);
+CREATE INDEX idx_proposals_created_by_user_id ON public.proposals(created_by_user_id);
+
+-- updated_at トリガー (既に trigger_set_timestamp() 関数が定義されていると仮定)
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON public.proposals
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();

--- a/system_configurations.sql
+++ b/system_configurations.sql
@@ -1,0 +1,33 @@
+-- システム設定テーブル
+CREATE TABLE public.system_configurations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(), -- 設定ID
+    key TEXT UNIQUE NOT NULL, -- 設定キー (例: "email_batch_interval_minutes")
+    value TEXT NOT NULL, -- 設定値
+    description TEXT, -- 設定内容の説明
+    value_type TEXT NOT NULL DEFAULT 'string' CHECK (value_type IN ('string', 'integer', 'float', 'boolean', 'json')), -- 値のデータ型 (文字列, 整数, 浮動小数点数, 真偽値, JSON)
+    is_enabled BOOLEAN NOT NULL DEFAULT true, -- 有効フラグ (この設定が有効かどうか)
+    created_at TIMESTAMPTZ DEFAULT now(), -- 作成日時
+    updated_at TIMESTAMPTZ DEFAULT now() -- 更新日時
+);
+
+-- コメント追加
+COMMENT ON TABLE public.system_configurations IS 'システム設定テーブル';
+COMMENT ON COLUMN public.system_configurations.id IS '設定ID';
+COMMENT ON COLUMN public.system_configurations.key IS '設定キー (例: "email_batch_interval_minutes")';
+COMMENT ON COLUMN public.system_configurations.value IS '設定値';
+COMMENT ON COLUMN public.system_configurations.description IS '設定内容の説明';
+COMMENT ON COLUMN public.system_configurations.value_type IS '値のデータ型 (文字列, 整数, 浮動小数点数, 真偽値, JSON)';
+COMMENT ON COLUMN public.system_configurations.is_enabled IS '有効フラグ (この設定が有効かどうか)';
+COMMENT ON COLUMN public.system_configurations.created_at IS '作成日時';
+COMMENT ON COLUMN public.system_configurations.updated_at IS '更新日時';
+
+-- インデックス作成
+-- key は UNIQUE constraint により自動的にインデックスが作成されますが、明示的に定義することも可能です。
+-- CREATE UNIQUE INDEX idx_system_configurations_key ON public.system_configurations(key);
+CREATE INDEX idx_system_configurations_is_enabled ON public.system_configurations(is_enabled);
+
+-- updated_at トリガー (既に trigger_set_timestamp() 関数が定義されていると仮定)
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON public.system_configurations
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();


### PR DESCRIPTION
This commit includes the initial design and SQL DDL generation for several new tables required for the talent matching platform.

The following tables have been designed and their DDL generated:
- public.engineers: Stores information about engineers/technicians, including AI-extracted resume data.
- public.projects: Stores project/case details, including AI-extracted information from various sources.
- public.emails: Manages ingested emails for automatic extraction of project or engineer information.
- public.project_engineer_matches: Tracks AI-generated and manual matches between projects and engineers.
- public.proposals: Manages proposals and recommendations sent based on matches.
- public.system_configurations: A key-value store for system-wide settings and parameters.

The existing `tenants` table will be used for company information, and the `profiles` table for your information, with new tables linking to them as appropriate.

Each new table DDL includes:
- Column definitions with appropriate data types.
- Primary and foreign key relationships.
- Constraints (NOT NULL, UNIQUE, CHECK).
- Indexes for query optimization (including GIN indexes for JSONB fields).
- Chinese comments for table and column descriptions.
- An automatic `updated_at` timestamp trigger.

The DDL files generated are:
- engineers.sql
- projects.sql
- emails.sql
- project_engineer_matches.sql
- proposals.sql
- system_configurations.sql